### PR TITLE
17.3 EXCERCISE: add productDao()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+//println project
+
 plugins {
     id 'org.springframework.boot' version '2.1.4.RELEASE'
     id 'java'

--- a/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Item.java
+++ b/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Item.java
@@ -36,13 +36,13 @@ public class Item {
         this.id = id;
     }
 
-/*    @ManyToOne
-    @JoinColumn(name = "PRODUCT_ID")*/
-    @OneToOne(
+    @ManyToOne
+    @JoinColumn(name = "PRODUCT_ID")
+/*    @OneToOne(
         cascade = CascadeType.ALL,
         fetch = FetchType.EAGER
     )
-    @JoinColumn(name = "PRODUCT_ID")
+    @JoinColumn(name = "PRODUCT_ID")*/
     public Product getProduct() {
         return product;
     }

--- a/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Item.java
+++ b/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Item.java
@@ -38,11 +38,6 @@ public class Item {
 
     @ManyToOne
     @JoinColumn(name = "PRODUCT_ID")
-/*    @OneToOne(
-        cascade = CascadeType.ALL,
-        fetch = FetchType.EAGER
-    )
-    @JoinColumn(name = "PRODUCT_ID")*/
     public Product getProduct() {
         return product;
     }

--- a/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Product.java
+++ b/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Product.java
@@ -13,19 +13,6 @@ public class Product {
     private String name;
     private List<Item> items2 = new ArrayList<>();
 
-/*    @OneToOne(
-            cascade = CascadeType.ALL,
-            fetch = FetchType.EAGER
-    )
-    @JoinColumn(name = "ITEM_ID")*/
-    /*public Item getItem() {
-        return item;
-    }
-
-    public void setItem(Item item) {
-        this.item = item;
-    }*/
-
     public Product() {
     }
 

--- a/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Product.java
+++ b/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Product.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class Product {
     private int id;
     private String name;
-    private Item item;
+    private List<Item> items2 = new ArrayList<>();
 
 /*    @OneToOne(
             cascade = CascadeType.ALL,
@@ -61,11 +61,11 @@ public class Product {
             cascade = CascadeType.ALL,
             fetch = FetchType.LAZY
     )
-    public Item getItem() {
-        return item;
+    public List<Item> getItems2() {
+        return items2;
     }
 
-    public void setItem(Item item) {
-        this.item = item;
+    public void setItems2(List<Item> items2) {
+        this.items2 = items2;
     }
 }

--- a/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Product.java
+++ b/kodilla-hibernate/src/main/java/com/kodilla/hibernate/invoice/Product.java
@@ -11,19 +11,19 @@ import java.util.List;
 public class Product {
     private int id;
     private String name;
-    //private Item items;
+    private Item item;
 
 /*    @OneToOne(
             cascade = CascadeType.ALL,
             fetch = FetchType.EAGER
     )
     @JoinColumn(name = "ITEM_ID")*/
-/*    public Item getItems() {
-        return items;
+    /*public Item getItem() {
+        return item;
     }
 
-    public void setItems(Item items) {
-        this.items = items;
+    public void setItem(Item item) {
+        this.item = item;
     }*/
 
     public Product() {
@@ -53,5 +53,19 @@ public class Product {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @OneToMany(
+            targetEntity = Item.class,
+            mappedBy = "product",
+            cascade = CascadeType.ALL,
+            fetch = FetchType.LAZY
+    )
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
     }
 }

--- a/kodilla-hibernate/src/test/java/com/kodilla/hibernate/invoice/dao/InvoiceDaoTestSuite.java
+++ b/kodilla-hibernate/src/test/java/com/kodilla/hibernate/invoice/dao/InvoiceDaoTestSuite.java
@@ -22,33 +22,38 @@ public class InvoiceDaoTestSuite {
     @Autowired
     private InvoiceDao invoiceDao;
 
+    @Autowired
+    private ProductDao productDao;
+
     @Test
     public void testInvoiceDaoSave() {
         //Given
+        Invoice invoice = new Invoice("2019/WA/LK");
+
         Product mirror = new Product("mirror");
         Product table = new Product("table");
         Product chair = new Product("chair");
 
-        Invoice invoice = new Invoice("2019/WA/LK");
-
         Item mirrorItem = new Item(new BigDecimal("123998"), 10, new BigDecimal(1239980));
-        Item tableItem = new Item(new BigDecimal("12094"), 1, new BigDecimal(12094));
-        Item chairItem = new Item(new BigDecimal("321099"), 100, new BigDecimal(32109900));
-
-/*        mirror.setItems(mirrorItem);
-        table.setItems(tableItem);
-        chair.setItems(chairItem);*/
         mirrorItem.setProduct(mirror);
-        tableItem.setProduct(table);
-        chairItem.setProduct(chair);
-
         mirrorItem.setInvoice(invoice);
+
+        Item tableItem = new Item(new BigDecimal("12094"), 1, new BigDecimal(12094));
+        tableItem.setProduct(table);
         tableItem.setInvoice(invoice);
+
+        Item chairItem = new Item(new BigDecimal("321099"), 100, new BigDecimal(32109900));
+        chairItem.setProduct(chair);
         chairItem.setInvoice(invoice);
 
-/*        mirror.getItems().add(mirrorItem);
-        table.getItems().add(tableItem);
-        chair.getItems().add(chairItem);*/
+/*        mirror.setItems2(mirrorItem);
+        table.setItems2(tableItem);
+        chair.setItems2(chairItem);*/
+
+
+        mirror.getItems2().add(mirrorItem);
+        table.getItems2().add(tableItem);
+        chair.getItems2().add(chairItem);
 
         invoice.getItems().add(mirrorItem);
         invoice.getItems().add(tableItem);
@@ -58,6 +63,13 @@ public class InvoiceDaoTestSuite {
 
         //When
         invoiceDao.save(invoice);
+/*
+        productDao.save(mirror);
+        productDao.save(table);
+        productDao.save(chair);
+*/
+
+
 
         //Then
         //int id = invoice.getId();

--- a/kodilla-hibernate/src/test/java/com/kodilla/hibernate/invoice/dao/InvoiceDaoTestSuite.java
+++ b/kodilla-hibernate/src/test/java/com/kodilla/hibernate/invoice/dao/InvoiceDaoTestSuite.java
@@ -11,8 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 @RunWith(SpringRunner.class)
@@ -46,10 +44,9 @@ public class InvoiceDaoTestSuite {
         chairItem.setProduct(chair);
         chairItem.setInvoice(invoice);
 
-/*        mirror.setItems2(mirrorItem);
-        table.setItems2(tableItem);
-        chair.setItems2(chairItem);*/
-
+        productDao.save(mirror);
+        productDao.save(table);
+        productDao.save(chair);
 
         mirror.getItems2().add(mirrorItem);
         table.getItems2().add(tableItem);
@@ -59,25 +56,17 @@ public class InvoiceDaoTestSuite {
         invoice.getItems().add(tableItem);
         invoice.getItems().add(chairItem);
 
-
-
         //When
         invoiceDao.save(invoice);
-/*
-        productDao.save(mirror);
-        productDao.save(table);
-        productDao.save(chair);
-*/
-
-
 
         //Then
-        //int id = invoice.getId();
-        //Optional<Invoice> readInvoice = invoiceDao.findById(id);
-        //Assert.assertTrue(readInvoice.isPresent());
+        int id = invoice.getId();
+        Optional<Invoice> readInvoice = invoiceDao.findById(id);
+        Assert.assertTrue(readInvoice.isPresent());
 
         //Cleanup
-        //invoiceDao.deleteById(id);
+        invoiceDao.deleteById(id);
+        productDao.deleteAll();
     }
 
 }


### PR DESCRIPTION
Wersja zadania modułu 17.3 po poprawkach z uwzględnieniem Twoich sugestii.
Mam kilka pytań:
1) czemu nie muszę używać itemDao.save() żeby zapisać rekordy w tabeli Items? A żeby zapisać rekordy w pozostałych tabelach (Porducts i Invoices) musi być metoda save() jawnie wywołana? Skąd Spring wie, jak uzupełnić dane w tabeli Items?
2) Czemu w bloku //Cleanup metoda invoiceDao.deleteById(id); usuwa rekordy tylko z tabel Invoices i Items a z Products już nie? Czemu nie trzeba użyć tutaj itemDao.deleteAll()?