### PR TITLE
Module24.5 excercise

### DIFF
--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/MedianAdaptee.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/MedianAdaptee.java
@@ -1,0 +1,21 @@
+package com.kodilla.patterns2.adapter.bookclassifier;
+
+import com.kodilla.patterns2.adapter.bookclassifier.libraryb.BookB;
+import com.kodilla.patterns2.adapter.bookclassifier.libraryb.BookSignature;
+import com.kodilla.patterns2.adapter.bookclassifier.libraryb.BookStatistics;
+import com.kodilla.patterns2.adapter.bookclassifier.libraryb.Statistics;
+
+import java.util.Map;
+
+public class MedianAdaptee implements BookStatistics {
+    @Override
+    public int averagePublicationYear(Map<BookSignature, BookB> books) {
+        Statistics statistics = new Statistics();
+        return statistics.averagePublicationYear(books);
+    }
+    @Override
+    public int medianPublicationYear(Map<BookSignature, BookB> books) {
+        Statistics statistics = new Statistics();
+        return statistics.medianPublicationYear(books);
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/MedianAdapter.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/MedianAdapter.java
@@ -1,0 +1,29 @@
+package com.kodilla.patterns2.adapter.bookclassifier;
+
+import com.kodilla.patterns2.adapter.bookclassifier.librarya.Book;
+import com.kodilla.patterns2.adapter.bookclassifier.librarya.Classifier;
+import com.kodilla.patterns2.adapter.bookclassifier.libraryb.BookB;
+import com.kodilla.patterns2.adapter.bookclassifier.libraryb.BookSignature;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class MedianAdapter extends MedianAdaptee implements Classifier {
+
+
+    @Override
+    public int publicationYearMedian(Set<Book> bookSet) {
+        Map<BookSignature, BookB> books = new HashMap<>();
+        for (Book book : bookSet) {
+            BookSignature bookSignature = new BookSignature(book.getSignature());
+            books.put(bookSignature, new BookB(
+                    book.getAuthor(),
+                    book.getTitle(),
+                    book.getPublicationYear()
+            ));
+        }
+        return medianPublicationYear(books);
+    }
+
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/librarya/Book.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/librarya/Book.java
@@ -1,0 +1,31 @@
+package com.kodilla.patterns2.adapter.bookclassifier.librarya;
+
+public class Book {
+    private final String author;
+    private final String title;
+    private final int publicationYear;
+    private final String signature;
+
+    public Book(String author, String title, int publicationYear, String signature) {
+        this.author = author;
+        this.title = title;
+        this.publicationYear = publicationYear;
+        this.signature = signature;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getPublicationYear() {
+        return publicationYear;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/librarya/Classifier.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/librarya/Classifier.java
@@ -1,0 +1,7 @@
+package com.kodilla.patterns2.adapter.bookclassifier.librarya;
+
+import java.util.Set;
+
+public interface Classifier {
+    int publicationYearMedian(Set<Book> bookSet);
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/Book.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/Book.java
@@ -1,0 +1,25 @@
+package com.kodilla.patterns2.adapter.bookclassifier.libraryb;
+
+public class Book {
+    private final String author;
+    private final String title;
+    private final int yearOfPublication;
+
+    public Book(String author, String title, int yearOfPublication) {
+        this.author = author;
+        this.title = title;
+        this.yearOfPublication = yearOfPublication;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getYearOfPublication() {
+        return yearOfPublication;
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookB.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookB.java
@@ -1,11 +1,11 @@
 package com.kodilla.patterns2.adapter.bookclassifier.libraryb;
 
-public class Book {
+public class BookB {
     private final String author;
     private final String title;
     private final int yearOfPublication;
 
-    public Book(String author, String title, int yearOfPublication) {
+    public BookB(String author, String title, int yearOfPublication) {
         this.author = author;
         this.title = title;
         this.yearOfPublication = yearOfPublication;

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookSignature.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookSignature.java
@@ -1,0 +1,13 @@
+package com.kodilla.patterns2.adapter.bookclassifier.libraryb;
+
+public class BookSignature {
+    private final String signature;
+
+    public BookSignature(String signature) {
+        this.signature = signature;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookStatistics.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookStatistics.java
@@ -1,0 +1,8 @@
+package com.kodilla.patterns2.adapter.bookclassifier.libraryb;
+
+import java.util.Map;
+
+public interface BookStatistics {
+    int averagePublicationYear(Map<BookSignature, Book> books);
+    int medianPublicationYear(Map<BookSignature, Book> books);
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookStatistics.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/BookStatistics.java
@@ -3,6 +3,6 @@ package com.kodilla.patterns2.adapter.bookclassifier.libraryb;
 import java.util.Map;
 
 public interface BookStatistics {
-    int averagePublicationYear(Map<BookSignature, Book> books);
-    int medianPublicationYear(Map<BookSignature, Book> books);
+    int averagePublicationYear(Map<BookSignature, BookB> books);
+    int medianPublicationYear(Map<BookSignature, BookB> books);
 }

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/Statistics.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/Statistics.java
@@ -1,0 +1,32 @@
+package com.kodilla.patterns2.adapter.bookclassifier.libraryb;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class Statistics implements BookStatistics {
+    @Override
+    public int averagePublicationYear(Map<BookSignature, Book> books) {
+        if(books.size() == 0) return 0;
+        int sum = 0;
+        for(Map.Entry<BookSignature, Book> entry : books.entrySet()) {
+            sum += entry.getValue().getYearOfPublication();
+        }
+        return sum / books.size();
+    }
+    @Override
+    public int medianPublicationYear(Map<BookSignature, Book> books) {
+        if(books.size() == 0) return 0;
+        int[] years = new int[books.size()];
+        int n = 0;
+        for(Map.Entry<BookSignature, Book> entry : books.entrySet()) {
+            years[n] = entry.getValue().getYearOfPublication();
+            n++;
+        }
+        Arrays.sort(years);
+        if(years.length % 2 == 0) {
+            return years[(int)(years.length / 2 + 0.5)];
+        } else {
+            return years[years.length / 2];
+        }
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/Statistics.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/bookclassifier/libraryb/Statistics.java
@@ -5,20 +5,20 @@ import java.util.Map;
 
 public class Statistics implements BookStatistics {
     @Override
-    public int averagePublicationYear(Map<BookSignature, Book> books) {
+    public int averagePublicationYear(Map<BookSignature, BookB> books) {
         if(books.size() == 0) return 0;
         int sum = 0;
-        for(Map.Entry<BookSignature, Book> entry : books.entrySet()) {
+        for(Map.Entry<BookSignature, BookB> entry : books.entrySet()) {
             sum += entry.getValue().getYearOfPublication();
         }
         return sum / books.size();
     }
     @Override
-    public int medianPublicationYear(Map<BookSignature, Book> books) {
+    public int medianPublicationYear(Map<BookSignature, BookB> books) {
         if(books.size() == 0) return 0;
         int[] years = new int[books.size()];
         int n = 0;
-        for(Map.Entry<BookSignature, Book> entry : books.entrySet()) {
+        for(Map.Entry<BookSignature, BookB> entry : books.entrySet()) {
             years[n] = entry.getValue().getYearOfPublication();
             n++;
         }

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/SalaryAdaptee.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/SalaryAdaptee.java
@@ -1,0 +1,16 @@
+package com.kodilla.patterns2.adapter.company;
+
+import com.kodilla.patterns2.adapter.company.newhrsystem.CompanySalaryProcessor;
+import com.kodilla.patterns2.adapter.company.newhrsystem.Employee;
+import com.kodilla.patterns2.adapter.company.newhrsystem.SalaryProcessor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class SalaryAdaptee implements SalaryProcessor {
+    @Override
+    public BigDecimal calculateSalaries (List<Employee> employees) {
+        CompanySalaryProcessor theProcessor = new CompanySalaryProcessor();
+        return theProcessor.calculateSalaries(employees);
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/SalaryAdapter.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/SalaryAdapter.java
@@ -1,0 +1,23 @@
+package com.kodilla.patterns2.adapter.company;
+
+import com.kodilla.patterns2.adapter.company.newhrsystem.Employee;
+import com.kodilla.patterns2.adapter.company.oldhrsystem.SalaryCalculator;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SalaryAdapter extends SalaryAdaptee implements SalaryCalculator {
+    @Override
+    public double TotalSalary (String[][] workers, double[] salaries) {
+        List<Employee> employeeList = new ArrayList<>();
+        for(int n = 0; n < salaries.length; n++) {
+            employeeList.add(new Employee(
+                    workers[n][0],
+                    workers[n][1],
+                    workers[n][2],
+                    new BigDecimal(salaries[n])));
+        }
+            return calculateSalaries(employeeList).doubleValue();
+        }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/newhrsystem/CompanySalaryProcessor.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/newhrsystem/CompanySalaryProcessor.java
@@ -1,0 +1,16 @@
+package com.kodilla.patterns2.adapter.company.newhrsystem;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class CompanySalaryProcessor implements SalaryProcessor {
+    @Override
+    public BigDecimal calculateSalaries (List<Employee> employees) {
+        BigDecimal sum = BigDecimal.ZERO;
+        for (Employee employee : employees) {
+            System.out.println(employee);
+            sum = sum.add(employee.getBaseSalary());
+        }
+        return sum;
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/newhrsystem/Employee.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/newhrsystem/Employee.java
@@ -1,0 +1,65 @@
+package com.kodilla.patterns2.adapter.company.newhrsystem;
+
+import java.math.BigDecimal;
+
+public class Employee {
+    final private String peselId;
+    final private String firstName;
+    final private String lastName;
+    final private BigDecimal baseSalary;
+
+    public Employee(String peselId, String firstName, String lastName, BigDecimal baseSalary) {
+        this.peselId = peselId;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.baseSalary = baseSalary;
+    }
+
+    public String getPeselId() {
+        return peselId;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public BigDecimal getBaseSalary() {
+        return baseSalary;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Employee)) return false;
+
+        Employee employee = (Employee) o;
+
+        if (!getPeselId().equals(employee.getPeselId())) return false;
+        if (!getFirstName().equals(employee.getFirstName())) return false;
+        if (!getLastName().equals(employee.getLastName())) return false;
+        return getBaseSalary().equals(employee.getBaseSalary());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getPeselId().hashCode();
+        result = 31 * result + getFirstName().hashCode();
+        result = 31 * result + getLastName().hashCode();
+        result = 31 * result + getBaseSalary().hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Employee{" +
+                "peselId='" + peselId + '\'' +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", baseSalary=" + baseSalary +
+                '}';
+    }
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/newhrsystem/SalaryProcessor.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/newhrsystem/SalaryProcessor.java
@@ -1,0 +1,8 @@
+package com.kodilla.patterns2.adapter.company.newhrsystem;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface SalaryProcessor {
+    BigDecimal calculateSalaries(List<Employee> employees);
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/oldhrsystem/SalaryCalculator.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/oldhrsystem/SalaryCalculator.java
@@ -1,0 +1,5 @@
+package com.kodilla.patterns2.adapter.company.oldhrsystem;
+
+public interface SalaryCalculator {
+    double TotalSalary(String[][] workers, double[] salaries);
+}

--- a/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/oldhrsystem/Workers.java
+++ b/kodilla-patterns2/src/main/java/com/kodilla/patterns2/adapter/company/oldhrsystem/Workers.java
@@ -1,0 +1,30 @@
+package com.kodilla.patterns2.adapter.company.oldhrsystem;
+
+public class Workers {
+    private String[][] workers = {
+            {"987728939", "John", "Smith"},
+            {"987728938", "Mary", "Pic"},
+            {"987728935", "Leo", "Firff"},
+            {"987728934", "Mark", "Talks"},
+            {"987728931", "Steve", "Pepper"},
+    };
+    private double[] salaries = {
+            3400.00,
+            4230.99,
+            2123.34,
+            6678.9,
+            2304.45
+    };
+    public String getWorker(int n) {
+        if(n > salaries.length) {
+            return "";
+        }
+        return workers[n][0] + ", " + workers[n][1] + ", " + workers[n][2] + ", " + salaries[n];
+    }
+    public String[][] getWorkers() {
+        return workers;
+    }
+    public double[] getSalaries() {
+        return salaries;
+    }
+}

--- a/kodilla-patterns2/src/test/java/com/kodilla/patterns2/adapter/bookclassifier/MedianAdapterTestSuite.java
+++ b/kodilla-patterns2/src/test/java/com/kodilla/patterns2/adapter/bookclassifier/MedianAdapterTestSuite.java
@@ -1,0 +1,38 @@
+package com.kodilla.patterns2.adapter.bookclassifier;
+
+import com.kodilla.patterns2.adapter.bookclassifier.librarya.Book;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class MedianAdapterTestSuite {
+    @Test
+    public void testPublicationYearMedian() {
+        //Given
+        MedianAdapter medianAdapter = new MedianAdapter();
+        Set<Book> bookSet = new HashSet<>();
+
+        Book book1 = new Book("Autor1","Tytuł1", 2019, "sygnatura1");
+        Book book2 = new Book("Autor2","Tytuł2", 2000, "sygnatura2");
+        Book book3 = new Book("Autor3","Tytuł3", 2003, "sygnatura3");
+        Book book4 = new Book("Autor4","Tytuł4", 1976, "sygnatura4");
+        Book book5 = new Book("Autor5","Tytuł5", 1996, "sygnatura5");
+
+        bookSet.add(book1);
+        bookSet.add(book2);
+        bookSet.add(book3);
+        bookSet.add(book4);
+        bookSet.add(book5);
+
+        //When
+        int median = medianAdapter.publicationYearMedian(bookSet);
+
+        //Then
+        Assert.assertEquals(2000, median);
+
+    }
+}

--- a/kodilla-patterns2/src/test/java/com/kodilla/patterns2/adapter/company/SalaryAdapterTestSuite.java
+++ b/kodilla-patterns2/src/test/java/com/kodilla/patterns2/adapter/company/SalaryAdapterTestSuite.java
@@ -1,0 +1,20 @@
+package com.kodilla.patterns2.adapter.company;
+
+import com.kodilla.patterns2.adapter.company.oldhrsystem.Workers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SalaryAdapterTestSuite {
+    @Test
+    public void testTotalSalary() {
+        //Given
+        Workers workers = new Workers();
+        SalaryAdapter salaryAdapter = new SalaryAdapter();
+        //When
+        double totalSalary = salaryAdapter.TotalSalary(workers.getWorkers(), workers.getSalaries());
+        //Then
+        System.out.println(totalSalary);
+        assertEquals(totalSalary, 18737.68, 0);
+    }
+}


### PR DESCRIPTION
Mam pytanie:
w pakietach librarya i libraryb były klasy o tej samej nazwie tj. Book. Niestety nie udało mi się stworzyć klasy MedianAdapter bez zmiany nazwy jednej z tych klas. I wszystko się udało, kiedy klasę Book w libraryb zaminiłem na BookB. 
Czy jest jakiś sposób, żeby można było stworzyć klasę adaptera bez zmiany jednej z dublowanych nazw klas?
Z góry dzięki za odpowiedź